### PR TITLE
BUG: include dependabot.yml in default scope

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,7 @@
   description: "Find security issues in GitHub Actions CI/CD setups"
   language: python
   types: [yaml]
-  files: (\.github/workflows/.*)|(action\.ya?ml)$
+  files: (\.github/(workflows/.*|dependabot.yml))|(action\.ya?ml)$
   require_serial: true
   entry: zizmor
   args:


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] I hereby disclose the use of an LLM or other AI coding assistant in the
      creation of this PR. PRs will not be rejected for using AI tools, but
      *will* be rejected for undisclosed use.

If a checkbox is not applicable, you can leave it unchecked.

## Summary

fixes #17

## Test Plan

not sure how the pre-commit hook is tested, if at all, but this should be pretty simple to test manually. For instance, intentionally omitting a `cooldown` setting in `dependabot.yml` and running `pre-commit` to find that it's not flagged.
