### PR TITLE
RFC: remove pre-commit-hook `files` regexp, let `zizmor` select files to lint

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,6 @@
   description: "Find security issues in GitHub Actions CI/CD setups"
   language: python
   types: [yaml]
-  files: (\.github/(workflows/.*|dependabot.yml))|(action\.ya?ml)$
   require_serial: true
   entry: zizmor
   args:


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] I hereby disclose the use of an LLM or other AI coding assistant in the
      creation of this PR. PRs will not be rejected for using AI tools, but
      *will* be rejected for undisclosed use.


## Summary

close #19
It *is* actually that simple.

## Test Plan

add the following `pre-commit-config.yaml`
```
- repo: https://github.com/neutrinoceros/zizmor-pre-commit
  rev: 3ce49f019a4b40fcb03ba35f33bf2b69756f95a9
  hooks:
  - id: zizmor
```
(preferably in a repo that hasn't fixed all zizmor lints yet; so it's more visual)
run
```
pre-commit run zizmor --all-files
```
