### PR TITLE
Document autofixing behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ repos:
     - id: zizmor
 ```
 
+To autofix issues, set the following args:
+
+```yaml
+repos:
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  # Zizmor version.
+  rev: v1.24.1
+  hooks:
+    # Run the linter.
+    - id: zizmor
+      args: [--no-progress, --fix]
+```
+
+(`--no-progress` must be specified since that arg exists in the repo's hook configuration, and `args` overrides all existing args)
+
 [zizmor-pre-commit#22]: https://github.com/zizmorcore/zizmor-pre-commit/issues/22
 
 ## License


### PR DESCRIPTION
## Pre-submission checks
Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Resolves #29 - "So I think this would be a documentation change rather than a change to the hook itself"

## Test Plan

I am using this config in other repos (ex: [here](https://github.com/mxr/asyncio-for-ynab/blob/042e6475650bdddecc96dfe26ad69cbe31a9ef89/.pre-commit-config.yaml#L77)) without issues
