### PR TITLE
Use upstream zizmor release notes for releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,11 +52,22 @@ jobs:
       - name: create release on new tag if new changes exist
         if: env.changes_exist == 'true'
         run: |
-          TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))
+          TAG_NAME=$(git describe --tags "$(git rev-list --tags --max-count=1)")
+          RELEASE_NOTES=release-notes.md
+
+          gh release view "$TAG_NAME" \
+            --repo zizmorcore/zizmor \
+            --json body \
+            --jq '.body // ""' > "$RELEASE_NOTES"
+
+          if ! grep -q '[^[:space:]]' "$RELEASE_NOTES"; then
+            echo "See: https://github.com/zizmorcore/zizmor/releases/tag/${TAG_NAME}" > "$RELEASE_NOTES"
+          fi
+
           echo $TAG_NAME
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
-            --notes "See: https://github.com/zizmorcore/zizmor/releases/tag/${TAG_NAME}" \
+            --notes-file "$RELEASE_NOTES" \
             --latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,21 +53,23 @@ jobs:
         if: env.changes_exist == 'true'
         run: |
           TAG_NAME=$(git describe --tags "$(git rev-list --tags --max-count=1)")
-          RELEASE_NOTES=release-notes.md
+          RELEASE_NOTES_FILE=release-notes.md
 
-          gh release view "$TAG_NAME" \
+          RELEASE_NOTES=$(gh release view "$TAG_NAME" \
             --repo zizmorcore/zizmor \
             --json body \
-            --jq '.body // ""' > "$RELEASE_NOTES"
+            --jq '.body // ""')
 
-          if ! grep -q '[^[:space:]]' "$RELEASE_NOTES"; then
-            echo "See: https://github.com/zizmorcore/zizmor/releases/tag/${TAG_NAME}" > "$RELEASE_NOTES"
+          if [[ -z "$RELEASE_NOTES" ]]; then
+            RELEASE_NOTES="See: https://github.com/zizmorcore/zizmor/releases/tag/${TAG_NAME}"
           fi
 
-          echo $TAG_NAME
+          printf '%s\n' "$RELEASE_NOTES" > "$RELEASE_NOTES_FILE"
+
+          echo "$TAG_NAME"
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
-            --notes-file "$RELEASE_NOTES" \
+            --notes-file "$RELEASE_NOTES_FILE" \
             --latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Fixes #42

Updates the release workflow to populate `zizmor-pre-commit` GitHub releases with the matching upstream `zizmor` release notes instead of only linking to them.

If the upstream release body is empty, the workflow falls back to the existing release-specific link.

## Test Plan

- `uvx pre-commit run --all-files`
- `git diff --check`
- `gh release view v1.24.0 --repo zizmorcore/zizmor --json body --jq '.body // ""'`

<!-- IMPORTANT: Do not delete the following lines. -->
<!-- @@NUDNIK NEUTRALIZER@@ -->