### PR TITLE
chore: freeze pin commit hooks, bump usage of own hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: check-github-workflows
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.17.0
+    rev: v1.29.0
     hooks:
       - id: zizmor
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.12
+    rev: d19233b89771be2d89273f163f5edc5a39bbc34a  # frozen: v0.11.12
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -20,17 +20,17 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.30.0
+    rev: 9932a7df36a32ef5e79dfd5df26ad89ca15bfa61  # frozen: 0.30.0
     hooks:
       - id: check-github-workflows
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.29.0
+    rev: 451b56af716f9f0d0c2b816503a3fd0cf8b036fa  # frozen: v1.29.0
     hooks:
       - id: zizmor
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.23
+    rev: f45606bad11ad90ddac1212fa83ebe2a4d724351  # frozen: v0.23
     hooks:
       - id: validate-pyproject
 


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Pins all remote pre-commit hooks to their currently resolved commit SHAs for reproducibility. Also bumps usage of the project's own `zizmor` hook to its latest release, `v1.29.0`.

The remaining four hook changes strictly pin their `rev` to the currently resolved commit SHAs, and therefore are no-ops. However, these are all behind their latest release.  This is not especially urgent for this low-churn repository, but as a follow-up, it may be worthwhile to enable Dependabot's `pre-commit` ecosystem for automated hook updates.

| Repo | Previous ref | Pinned commit SHA | Release |
|---|---:|---|---|
| [`astral-sh/ruff-pre-commit`](https://github.com/astral-sh/ruff-pre-commit) | [`v0.11.12`](https://github.com/astral-sh/ruff-pre-commit/tree/v0.11.12) | [`d19233b`](https://github.com/astral-sh/ruff-pre-commit/commit/d19233b89771be2d89273f163f5edc5a39bbc34a) | [v0.11.12](https://github.com/astral-sh/ruff-pre-commit/releases/tag/v0.11.12) |
| [`pre-commit/pre-commit-hooks`](https://github.com/pre-commit/pre-commit-hooks) | [`v5.0.0`](https://github.com/pre-commit/pre-commit-hooks/tree/v5.0.0) | [`cef0300`](https://github.com/pre-commit/pre-commit-hooks/commit/cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b) | [v5.0.0](https://github.com/pre-commit/pre-commit-hooks/releases/tag/v5.0.0) |
| [`python-jsonschema/check-jsonschema`](https://github.com/python-jsonschema/check-jsonschema) | [`0.30.0`](https://github.com/python-jsonschema/check-jsonschema/tree/0.30.0) | [`9932a7d`](https://github.com/python-jsonschema/check-jsonschema/commit/9932a7df36a32ef5e79dfd5df26ad89ca15bfa61) | [0.30.0](https://github.com/python-jsonschema/check-jsonschema/releases/tag/0.30.0) |
| [`zizmorcore/zizmor-pre-commit`](https://github.com/zizmorcore/zizmor-pre-commit) | [`v1.17.0`](https://github.com/zizmorcore/zizmor-pre-commit/tree/v1.17.0) | [`451b56a`](https://github.com/zizmorcore/zizmor-pre-commit/commit/451b56af716f9f0d0c2b816503a3fd0cf8b036fa) | [v1.29.0](https://github.com/zizmorcore/zizmor-pre-commit/releases/tag/v1.29.0) |
| [`abravalheri/validate-pyproject`](https://github.com/abravalheri/validate-pyproject) | [`v0.23`](https://github.com/abravalheri/validate-pyproject/tree/v0.23) | [`f45606b`](https://github.com/abravalheri/validate-pyproject/commit/f45606bad11ad90ddac1212fa83ebe2a4d724351) | [v0.23](https://github.com/abravalheri/validate-pyproject/releases/tag/v0.23) |

## Test Plan

N/A

<!-- IMPORTANT: Do not delete the following lines. -->
<!-- @@NUDNIK NEUTRALIZER@@ -->
