### PR TITLE
fix: include pre-commit files in hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,12 @@
   description: "Find security issues in GitHub Actions CI/CD setups"
   language: python
   types: [yaml]
-  files: (\.github/(workflows/.*|dependabot.ya?ml))|(action\.ya?ml)$
+  # Select the YAML inputs supported by zizmor:
+  # - files directly under any `.github/workflows` directory;
+  # - `.github/dependabot.{yml,yaml}`;
+  # - `action.{yml,yaml}` anywhere; and
+  # - `.pre-commit-{config,hooks}.{yml,yaml}` anywhere.
+  files: (^|/)(\.github/(workflows/[^/]+|dependabot)\.ya?ml|action\.ya?ml|\.pre-commit-(config|hooks)\.ya?ml)$
   require_serial: true
   entry: zizmor
   args:


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Update the pre-commit hook's `files` pattern to include pre-commit configuration and hook-definition files (which gained `zizmor` support in 1.29.0).

The revised pattern also tightens the existing workflow, Dependabot, and action matches:
- Restricts workflows to YAML files directly inside `.github/workflows`; the old `workflows/.*` also matched subdirectories and non-YAML files.
- Requires an an exact  `action.yml` or `action.yaml`; the old alternative also matched names such as `my-action.yml` or `transaction.yaml`.
- Escapes the dot in `.github/dependabot.ya?ml`; the old wildcard dot would match names such as `dependabotXyml`.
- Rejects substring matches for `.github/`; previously paths like `foo.github/workflows/ci.yml` or `bar.github/dependabot.yml` would match

## Test Plan

Manually verified the updated `files` regex pattern conforms to expected behavior.

Also confirmed via `pre-commit/prek try-repo` that `.pre-commit-config.yaml`, `.pre-commit-config.yml`, and `.pre-commit-hooks.yml` are all selected and successfully audited by zizmor 1.29.0.

<!-- IMPORTANT: Do not delete the following lines. -->
<!-- @@NUDNIK NEUTRALIZER@@ -->
